### PR TITLE
Require Login to setup DnDtools for private use

### DIFF
--- a/dndtools/LoginRequiredMiddleware.py
+++ b/dndtools/LoginRequiredMiddleware.py
@@ -1,0 +1,29 @@
+from django.http import HttpResponseRedirect
+from django.conf import settings
+from re import compile
+
+EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+
+class LoginRequiredMiddleware:
+    """
+    Middleware that requires a user to be authenticated to view any page other
+    than LOGIN_URL. Exemptions to this requirement can optionally be specified
+    in settings via a list of regular expressions in LOGIN_EXEMPT_URLS (which
+    you can copy from your urls.py).
+
+    Requires authentication middleware and template context processors to be
+    loaded. You'll get an error if they aren't.
+    """
+    def process_request(self, request):
+        assert hasattr(request, 'user'), "The Login Required middleware\
+ requires authentication middleware to be installed. Edit your\
+ MIDDLEWARE_CLASSES setting to insert\
+ 'django.contrib.auth.middlware.AuthenticationMiddleware'. If that doesn't\
+ work, ensure your TEMPLATE_CONTEXT_PROCESSORS setting includes\
+ 'django.core.context_processors.auth'."
+        if not request.user.is_authenticated():
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return HttpResponseRedirect(settings.LOGIN_URL)

--- a/dndtools/LoginRequiredMiddleware.py
+++ b/dndtools/LoginRequiredMiddleware.py
@@ -1,10 +1,21 @@
-from django.http import HttpResponseRedirect
+# -*- coding: UTF-8 -*-
+
+# django dependencies
+from django.contrib.auth.views import redirect_to_login
+from django.contrib.auth import REDIRECT_FIELD_NAME
+# from django.http import HttpResponseRedirect
 from django.conf import settings
+
+# python dependencies
 from re import compile
+
+#---#
 
 EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
 if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
     EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+
+#---#
 
 class LoginRequiredMiddleware:
     """
@@ -25,5 +36,13 @@ class LoginRequiredMiddleware:
  'django.core.context_processors.auth'."
         if not request.user.is_authenticated():
             path = request.path_info.lstrip('/')
-            if not any(m.match(path) for m in EXEMPT_URLS):
-                return HttpResponseRedirect(settings.LOGIN_URL)
+            if not any(m.match(path) for m in EXEMPT_URLS): 
+                next = ""
+                if request.GET:  
+                    next = request.GET['next']
+                path = request.get_full_path()
+                if next == "":
+                    return redirect_to_login(path, settings.LOGIN_URL, REDIRECT_FIELD_NAME)
+                else:
+                    return HttpResponseRedirect(path)
+#---#

--- a/dndtools/dnd/urls.py
+++ b/dndtools/dnd/urls.py
@@ -74,6 +74,10 @@ urlpatterns = patterns(
     (r'^rss.xml$', AdminLogFeed()),
     (r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps}),
 
+	#login
+	url(r'^login/$', 'user_login', name='login'),
+	url(r'^logout/$', 'user_logout', name='logout'),
+	
     # job
     url(
         r'^very_secret_url/$',

--- a/dndtools/dnd/views.py
+++ b/dndtools/dnd/views.py
@@ -162,7 +162,16 @@ def very_secret_url(request):
 def user_login(request):
     # Like before, obtain the context for the user's request.
     context = RequestContext(request)
+    
+    next = ""
 
+    if request.GET:  
+        next = request.GET['next']
+        
+    if request.user.is_authenticated():
+        if next != "":
+            return HttpResponseRedirect(next);
+    
     # If the request is a HTTP POST, try to pull out the relevant information.
     if request.method == 'POST':
         # Gather the username and password provided by the user.
@@ -184,7 +193,10 @@ def user_login(request):
                 # We'll send the user back to the homepage.
                 login(request, user)
 				
-                return HttpResponseRedirect('/')
+                if next == "":
+                    return HttpResponseRedirect('/')
+                else:
+                    return HttpResponseRedirect(next)                
             else:
                 # An inactive account was used - no logging in!
                 return HttpResponse("Your account is disabled.")
@@ -198,7 +210,10 @@ def user_login(request):
     else:
         # No context variables to pass to the template system, hence the
         # blank dictionary object...
-        return render_to_response('dnd/login.html', {}, context)
+         if next == "":
+            return render_to_response('dnd/login.html', {}, context)
+         else:
+            return render_to_response('dnd/login.html', {'next': next }, context)
 
 # Use the login_required() decorator to ensure only those logged in can access the view.
 @login_required

--- a/dndtools/dnd/views.py
+++ b/dndtools/dnd/views.py
@@ -2,7 +2,9 @@
 
 from django.core.mail.message import EmailMessage
 from django.core.urlresolvers import reverse
-from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect, HttpResponse
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
 from dnd.menu import menu_item, submenu_item, MenuItem
@@ -157,4 +159,52 @@ def very_secret_url(request):
                                   'log': log,
                               }, context_instance=RequestContext(request), )
 
+def user_login(request):
+    # Like before, obtain the context for the user's request.
+    context = RequestContext(request)
 
+    # If the request is a HTTP POST, try to pull out the relevant information.
+    if request.method == 'POST':
+        # Gather the username and password provided by the user.
+        # This information is obtained from the login form.
+        username = request.POST['username']
+        password = request.POST['password']
+
+        # Use Django's machinery to attempt to see if the username/password
+        # combination is valid - a User object is returned if it is.
+        user = authenticate(username=username, password=password)
+
+        # If we have a User object, the details are correct.
+        # If None (Python's way of representing the absence of a value), no user
+        # with matching credentials was found.
+        if user:
+            # Is the account active? It could have been disabled.
+            if user.is_active:
+                # If the account is valid and active, we can log the user in.
+                # We'll send the user back to the homepage.
+                login(request, user)
+				
+                return HttpResponseRedirect('/')
+            else:
+                # An inactive account was used - no logging in!
+                return HttpResponse("Your account is disabled.")
+        else:
+            # Bad login details were provided. So we can't log the user in.
+            print "Invalid login details: {0}, {1}".format(username, password)
+            return HttpResponse("Invalid login details supplied.")
+
+    # The request is not a HTTP POST, so display the login form.
+    # This scenario would most likely be a HTTP GET.
+    else:
+        # No context variables to pass to the template system, hence the
+        # blank dictionary object...
+        return render_to_response('dnd/login.html', {}, context)
+
+# Use the login_required() decorator to ensure only those logged in can access the view.
+@login_required
+def user_logout(request):
+    # Since we know the user is logged in, we can now just log them out.
+    logout(request)
+
+    # Take the user back to the homepage.
+    return HttpResponseRedirect('/')

--- a/dndtools/dndproject/settings.py
+++ b/dndtools/dndproject/settings.py
@@ -27,6 +27,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'pagination.middleware.PaginationMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
+	'LoginRequiredMiddleware.LoginRequiredMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS += (
@@ -51,12 +52,15 @@ INSTALLED_APPS = (
     'south',
     'debug_toolbar',
     'django.contrib.sitemaps',
+	'LoginRequiredMiddleware',
 )
 
 SERVER_EMAIL = 'error@dndtools.eu'
 USE_TZ = False
 
 # LOCAL PY
+
+LOGIN_URL = '/login'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')

--- a/dndtools/templates/dnd/layout.html
+++ b/dndtools/templates/dnd/layout.html
@@ -67,6 +67,15 @@
 
                 <h2>Feats. Spells. Prestige Classes. And more!</h2>
             </div>
+			<div style="position: relative; left:300px;" >
+				{% if user.is_authenticated %}				
+				<h3>{{ user.username }}</h3>
+				<a href="/logout/">Logout</a><br />
+				{% else %}				
+				<a href="/login/">Login</a><br />
+				{% endif %}
+			</div>
+			
             {# Google search engine  #}
             {% if not debug %}
                 <div id="google-search-holder">

--- a/dndtools/templates/dnd/login.html
+++ b/dndtools/templates/dnd/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- Is anyone getting tired of repeatedly entering the header over and over?? -->
+        <title>Log In</title>
+    </head>
+
+    <body>
+        <h1>Login</h1>
+
+        <form id="login_form" method="post" action="/login/">
+            {% csrf_token %}
+            Username: <input type="text" name="username" value="" size="50" />
+            <br />
+            Password: <input type="password" name="password" value="" size="50" />
+            <br />
+
+            <input type="submit" value="submit" />
+        </form>
+
+    </body>
+</html>

--- a/dndtools/templates/dnd/login.html
+++ b/dndtools/templates/dnd/login.html
@@ -7,8 +7,11 @@
 
     <body>
         <h1>Login</h1>
-
-        <form id="login_form" method="post" action="/login/">
+        {% if next %}
+        <form id="login_form" action="/login/?next={{next}}" method="post" >
+        {%else%}
+        <form id="login_form" action="/login/" method="post" >
+        {% endif %}        
             {% csrf_token %}
             Username: <input type="text" name="username" value="" size="50" />
             <br />

--- a/dndtools/templates/dnd/rules/rule_detail.html
+++ b/dndtools/templates/dnd/rules/rule_detail.html
@@ -24,7 +24,8 @@
     <h2>{{ rule.name }}</h2>
     (<a href="{{ rulebook.get_absolute_url }}">{{ rulebook.name }}</a>{% if rule.page_from %},  p. {{ rule.page_from }}{% if rule.page_to %}&mdash;{{ rule.page_to }}{% endif %}{% endif %})
 
-    {{ rule.body_html|safe }}
-
+	<div class="nice-textile">
+		{{ rule.body_html|safe }}
+	</div>
 
 {% endblock %}


### PR DESCRIPTION
Basic login based on the users managed in the admin panel, logged in users can view,
otherwise an ugly basic login page is shown. Quick hack based on what I
was able to piece together from the internet.

It could use a setting to enable/disable, but I still need to get more familiar with how python works.
commenting out the 'LoginRequiredMiddleware.LoginRequiredMiddleware' and 'LoginRequiredMiddleware' additions from setting.py is enough to enable / disable the login requirement.

Now also fixes external application checking the link (like office does) and present a redirect after login.
if the user happens to be authenticated on a page with a redirect, it will auto-login / redirect immediately.

fixing the issue of stranding an office user on the home page, linking to pages behind the login wall (redirect after login) and automating it if it can (authenticated, but on redirecting login page = auto redirect)